### PR TITLE
Add Site Info and Page Info APIs

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -61,4 +61,6 @@ PMA_HOST=autotest_mysql
 PMA_PORT=3306
 FRONTEND_PORT=3000:80
 PAGE_CRAWL_MAX_DEPTH=2
+
+VITE_API_URL=/api/v1
 VITE_WS_URL=ws://localhost:8000/api/v1/ws

--- a/backend/app/routers/pages.py
+++ b/backend/app/routers/pages.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
-from app.schemas.page_schema import PaginatedPageResponse
+from app.schemas.page_schema import PaginatedPageResponse,PageInfoResponse
 from app.services.page_service import PageService
 from app.middleware.auth_middleware import auth_required
 from shared_orm.models.user import User
@@ -45,6 +45,20 @@ def list_unlinked_pages(
         "limit": limit,
         "data": pages
     }
+
+@router.get("/info", response_model=PageInfoResponse)
+def get_page_info(
+    page_id: int,
+    site_id: int | None = None,
+    db: Session = Depends(get_db),
+    user: User = Depends(auth_required)
+):
+    return page_service.get_page_info(
+        page_id=page_id,
+        site_id=site_id,
+        db=db,
+        user=user
+    )
 
 
 

--- a/backend/app/routers/site.py
+++ b/backend/app/routers/site.py
@@ -6,7 +6,8 @@ from app.schemas.site_schema import (
     SiteCreate,
     SiteUpdate,
     SiteResponse,
-    PaginatedSiteResponse
+    PaginatedSiteResponse,
+    SiteInfoResponse
 )
 from app.services.site_service import SiteService
 from app.services.page_service import PageService
@@ -168,5 +169,13 @@ def get_pages_by_site(
         "limit": limit,
         "data": pages
     }
+
+@router.get("/{site_id}/info", response_model=SiteInfoResponse)
+def get_site_info(
+    site_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(auth_required)
+):
+    return site_service.get_site_info(site_id, db, user)
 
 

--- a/backend/app/schemas/page_schema.py
+++ b/backend/app/schemas/page_schema.py
@@ -26,3 +26,18 @@ class PaginatedPageResponse(BaseModel):
     page: int
     limit: int
     data: List[PageResponse]
+
+
+class PageInfoResponse(BaseModel):
+    page_id: int
+    page_title: str | None
+    page_url: str
+    status:str
+
+    created_on: datetime | None
+    updated_on: datetime | None
+
+    test_scenario_count: int
+    test_case_count: int
+    scheduled_test_case_count: int
+

--- a/backend/app/schemas/site_schema.py
+++ b/backend/app/schemas/site_schema.py
@@ -32,3 +32,22 @@ class PaginatedSiteResponse(BaseModel):
     page: int
     limit: int
     data: List[SiteResponse]
+
+
+class SiteInfoResponse(BaseModel):
+    site_id: int
+    site_title: str
+    site_url: str
+    status: str
+
+    created_on: datetime | None
+    updated_on: datetime | None
+
+    page_count: int
+    test_scenario_count: int
+    test_case_count: int
+    test_suite_count: int
+
+    test_environment: int | None = None
+    scheduled_test_cases: int | None = None
+

--- a/backend/app/services/page_service.py
+++ b/backend/app/services/page_service.py
@@ -5,6 +5,10 @@ from sqlalchemy import or_, asc, desc
 from shared_orm.models.page import Page
 from shared_orm.models.site import Site
 from shared_orm.models.user import User
+from sqlalchemy import func
+from shared_orm.models.test_case import TestCase
+from shared_orm.models.test_scenario import TestScenario
+from app.schemas.page_schema import PageInfoResponse
 
 
 class PageService:
@@ -88,3 +92,60 @@ class PageService:
         pages = query.offset((page - 1) * limit).limit(limit).all()
 
         return total, pages
+    def get_page_info(
+        self,
+        page_id: int,
+        db: Session,
+        user: User,
+        site_id: int | None = None
+    ) -> PageInfoResponse:
+
+        
+        if not page_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="page_id is required"
+            )
+
+        page = db.query(Page).filter(Page.id == page_id).first()
+        if not page:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Page not found"
+            )
+
+        if site_id is not None:
+            if page.site_id != site_id:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Page does not belong to the given site"
+                )
+                
+        else:
+            if page.site_id is not None:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="This page is already linked to a site and is not a normal page"
+                )
+
+        test_scenario_count = db.query(func.count(TestScenario.id)) \
+            .filter(TestScenario.page_id == page.id) \
+            .scalar()
+
+        test_case_count = db.query(func.count(TestCase.id)) \
+            .filter(TestCase.page_id == page.id) \
+            .scalar()
+
+        scheduled_test_case_count = 0
+
+        return PageInfoResponse(
+            page_id=page.id,
+            page_title=page.page_title,
+            status=page.status,
+            page_url=page.page_url,
+            created_on=page.created_on,
+            updated_on=page.updated_on,
+            test_scenario_count=test_scenario_count or 0,
+            test_case_count=test_case_count or 0,
+            scheduled_test_case_count=scheduled_test_case_count
+        )

--- a/backend/app/services/site_service.py
+++ b/backend/app/services/site_service.py
@@ -3,13 +3,18 @@ from sqlalchemy.orm import Session
 from sqlalchemy import or_, asc, desc
 from fastapi import HTTPException, status
 from datetime import datetime
-
+from sqlalchemy import func
 from shared_orm.models.site import Site
-from app.schemas.site_schema import SiteCreate, SiteUpdate
+from app.schemas.site_schema import SiteCreate, SiteUpdate,SiteInfoResponse
 from shared_orm.models.user import User
 from app.messaging.rabbitmq_producer import rabbitmq_producer
 from app.config.setting import settings
 from app.config.logger import logger
+from shared_orm.models.test_scenario import TestScenario
+from shared_orm.models.test_case import TestCase
+from shared_orm.models.test_suite import TestSuite
+from shared_orm.models.page import Page
+
 
 class SiteService:
 
@@ -112,60 +117,45 @@ class SiteService:
         site = self.get_site_by_id(site_id, db)
         db.delete(site)
         db.commit()
+
+    def get_site_info(self, site_id: int, db: Session, user: User) -> SiteInfoResponse:
+        site = db.query(Site).filter(Site.id == site_id).first()
+        if not site:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Site not found"
+            )
+        page_count = db.query(func.count(Page.id)) \
+            .filter(Page.site_id == site_id) \
+            .scalar()
+
+        test_scenario_count = db.query(func.count(TestScenario.id)) \
+            .join(Page, TestScenario.page_id == Page.id) \
+            .filter(Page.site_id == site_id) \
+            .scalar()
+
+        test_case_count = db.query(func.count(TestCase.id)) \
+            .join(Page, TestCase.page_id == Page.id) \
+            .filter(Page.site_id == site_id) \
+            .scalar()
+
+        test_suite_count = db.query(func.count(TestSuite.id)) \
+            .filter(TestSuite.site_id == site_id) \
+            .scalar()
+
+        return SiteInfoResponse(
+            site_id=site.id,
+            site_title=site.site_title,
+            site_url=site.site_url,
+            status=site.status,
+            created_on=site.created_on,
+            updated_on=site.updated_on,
+            page_count=page_count or 0,
+            test_scenario_count=test_scenario_count or 0,
+            test_case_count=test_case_count or 0,
+            test_suite_count=test_suite_count or 0,
+            test_environment=None,          
+            scheduled_test_cases=None      
+        )
         
-    # async def analyse_site(
-    #     self,
-    #     site_id: int,
-    #     db: Session,
-    #     current_user: User,
-    # ) -> None:
-    #     """
-    #     Analyse a site:
-    #     - Validate site exists
-    #     - Update site status to Processing
-    #     - Publish analyse message to RabbitMQ
-    #     """
-
-    #     site = db.query(Site).filter(Site.id == site_id).first()
-
-    #     if not site:
-    #         raise HTTPException(
-    #             status_code=status.HTTP_404_NOT_FOUND,
-    #             detail="Site not found"
-    #         )
-
-    #     # Optional: prevent duplicate analyse
-    #     if site.status == "Processing":
-    #         raise HTTPException(
-    #             status_code=status.HTTP_409_CONFLICT,
-    #             detail="Site is already being analysed"
-    #         )
-
-    #     # Message payload
-    #     message = {
-    #         "event": "SITE_ANALYSE",
-    #         "site_id": site.id,
-    #         "site_url": site.site_url,
-    #         "requested_by": current_user.id,
-    #         "timestamp": datetime.utcnow().isoformat(),
-    #     }
-
-    #     published = await rabbitmq_producer.publish_message(
-    #         queue_name="site_analyse_queue",
-    #         message=message,
-    #         priority=5,
-    #     )
-
-    #     if not published:
-    #         raise HTTPException(
-    #             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-    #             detail="Failed to queue site for analysis"
-    #         )
-    #     # Update site status
-    #     site.status = "Processing"
-    #     site.updated_on = datetime.utcnow()
-    #     site.updated_by = current_user.id
-
-    #     db.commit()
-        
-    #     return {site,published}
+    


### PR DESCRIPTION
## Summary
This PR adds new APIs to fetch aggregated information for sites and pages.

## What’s included
- Site Info API to retrieve:
  - Site details (title, URL, status, created/updated timestamps)
  - Page count
  - Test scenario count
  - Test case count
  - Test suite count

- Page Info API with conditional logic:
  - page_id is mandatory
  - site_id is optional
  - If site_id is provided, page must belong to the given site
  - If site_id is not provided, page must be an unlinked (normal) page
  - Proper validation and error messages for invalid cases

## API Endpoints
- `GET /sites/{site_id}/info`
- `GET /pages/{page_id}/info?site_id={site_id}`

## Notes
- Counts are calculated using optimized aggregate queries
- Designed to be extensible for future fields (scheduled test cases, test environment)

