### PR TITLE
Refactor LLM provider selection to use DB and enforce single active provider

### DIFF
--- a/frontend/src/components/setting/LlmSettings.tsx
+++ b/frontend/src/components/setting/LlmSettings.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { Input } from '@/components/ui/input'
-import { Checkbox } from '@/components/ui/checkbox'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Textarea } from '@/components/ui/textarea'
-import { useProvidersQuery } from '@/utils/queries/providerQueries'
-import { useBulkUpdateProvidersMutation, useProviderModelsQuery, useBulkUpdateProviderModelsMutation } from '@/utils/queries/providerQueries'
+import {
+  useProvidersQuery,
+  useBulkUpdateProvidersMutation,
+  useProviderModelsQuery,
+  useBulkUpdateProviderModelsMutation,
+} from '@/utils/queries/providerQueries'
 import { CollapsibleSection } from './CollapsibleSection'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 
@@ -17,19 +20,20 @@ interface EditableProvider {
 }
 
 export const LlmSettings = () => {
-
   const { data: providers, isLoading } = useProvidersQuery()
   const { mutate: bulkUpdateProviders, isPaused: isSaving } = useBulkUpdateProvidersMutation()
+
   const [editableProviders, setEditableProviders] = useState<EditableProvider[]>([])
   const [selectedProviderId, setSelectedProviderId] = useState<number | null>(null)
   const [editableModels, setEditableModels] = useState<any[]>([])
   const [originalModels, setOriginalModels] = useState<any[]>([])
   const [originalProviders, setOriginalProviders] = useState<EditableProvider[]>([])
 
-
+  // Set default selected provider
   useEffect(() => {
     if (providers?.length && !selectedProviderId) {
-      setSelectedProviderId(providers[0].id)
+      const activeProvider = providers.find((p) => p.is_active)
+      setSelectedProviderId(activeProvider?.id ?? providers[0].id)
     }
   }, [providers, selectedProviderId])
 
@@ -37,6 +41,7 @@ export const LlmSettings = () => {
     selectedProviderId ?? 0,
   )
 
+  // Map providers
   useEffect(() => {
     if (providers) {
       const mappedProviders = providers.map((p) => ({
@@ -47,21 +52,56 @@ export const LlmSettings = () => {
       }))
 
       setEditableProviders(mappedProviders)
-      setOriginalProviders(mappedProviders) 
+      setOriginalProviders(mappedProviders)
     }
   }, [providers])
 
-
+  // Load models
   useEffect(() => {
     if (providerModels?.models) {
       setEditableModels(providerModels.models)
       setOriginalModels(providerModels.models)
     }
   }, [providerModels])
+
+  // Handle provider selection (ONLY ONE ACTIVE)
+  const handleToggle = (providerId: number) => {
+    setEditableProviders((prev) =>
+      prev.map((p) => ({
+        ...p,
+        is_active: p.provider_id === providerId,
+      })),
+    )
+  }
+
+  const handleKeyChange = (providerId: number, value: string) => {
+    setEditableProviders((prev) =>
+      prev.map((p) => (p.provider_id === providerId ? { ...p, key: value } : p)),
+    )
+  }
+
+  // Model change
   const handleModelChange = (modelId: number, field: 'temperature' | 'prompt', value: any) => {
     setEditableModels((prev) => prev.map((m) => (m.id === modelId ? { ...m, [field]: value } : m)))
   }
 
+  // Detect model changes
+  const hasModelChanges = editableModels.some((edited) => {
+    const original = originalModels.find((o) => o.id === edited.id)
+    if (!original) return false
+
+    return original.temperature !== edited.temperature || original.prompt !== edited.prompt
+  })
+
+  // Detect provider changes
+  const hasProviderChanges = editableProviders.some((edited) => {
+    const original = originalProviders.find((o) => o.provider_id === edited.provider_id)
+    if (!original) return false
+
+    return original.is_active !== edited.is_active || original.key !== edited.key
+  })
+
+  // Prepare models payload
   const getUpdatedModelsPayload = () => {
     return editableModels
       .filter((edited) => {
@@ -92,7 +132,7 @@ export const LlmSettings = () => {
     saveProviderModels(payload, {
       onSuccess: () => {
         toast.success('Model settings updated successfully')
-         setOriginalModels(editableModels)
+        setOriginalModels(editableModels)
       },
       onError: (error: any) => {
         toast.error(error?.response?.data?.detail || 'Failed to update models')
@@ -100,44 +140,17 @@ export const LlmSettings = () => {
     })
   }
 
-  const handleToggle = (providerId: number, checked: boolean) => {
-    setEditableProviders((prev) =>
-      prev.map((p) => (p.provider_id === providerId ? { ...p, is_active: checked } : p)),
-    )
-  }
-
-  const handleKeyChange = (providerId: number, value: string) => {
-    setEditableProviders((prev) =>
-      prev.map((p) => (p.provider_id === providerId ? { ...p, key: value } : p)),
-    )
-  }
-  const hasModelChanges = editableModels.some((edited) => {
-    const original = originalModels.find((o) => o.id === edited.id)
-    if (!original) return false
-
-    return original.temperature !== edited.temperature || original.prompt !== edited.prompt
-  })
-
-  const hasProviderChanges = editableProviders.some((edited) => {
-    const original = originalProviders.find((o) => o.provider_id === edited.provider_id)
-    if (!original) return false
-
-    return original.is_active !== edited.is_active || original.key !== edited.key
-  })
-
-
+  // Save providers
   const handleSaveProviders = () => {
-    const hasAtLeastOneActive = editableProviders.some((p) => p.is_active)
+    const activeProvider = editableProviders.find((p) => p.is_active)
 
-    if (!hasAtLeastOneActive) {
-      toast.error('At least one provider must be enabled')
+    if (!activeProvider) {
+      toast.error('One provider must be selected')
       return
     }
 
-    const invalidProvider = editableProviders.find((p) => p.is_active && !p.key.trim())
-
-    if (invalidProvider) {
-      toast.error(`Key is required for ${invalidProvider.title}`)
+    if (!activeProvider.key.trim()) {
+      toast.error(`Key is required for ${activeProvider.title}`)
       return
     }
 
@@ -154,22 +167,27 @@ export const LlmSettings = () => {
 
   return (
     <div className="space-y-6">
-      <CollapsibleSection title="API Provider" onSave={handleSaveProviders} loading={isSaving}disabled={!hasProviderChanges}>
+      {/* PROVIDERS */}
+      <CollapsibleSection
+        title="API Provider"
+        onSave={handleSaveProviders}
+        loading={isSaving}
+        disabled={!hasProviderChanges}
+      >
         {isLoading ? (
           <div className="flex justify-center py-6">
             <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary" />
           </div>
         ) : (
-          <div className="grid grid-cols-2 gap-6">
+          <RadioGroup
+            value={editableProviders.find((p) => p.is_active)?.provider_id.toString() ?? ''}
+            onValueChange={(value) => handleToggle(Number(value))}
+            className="grid grid-cols-2 gap-6"
+          >
             {editableProviders.map((provider) => (
               <div key={provider.provider_id} className="space-y-2">
                 <div className="flex items-center gap-2">
-                  <Checkbox
-                    checked={provider.is_active}
-                    onCheckedChange={(checked) =>
-                      handleToggle(provider.provider_id, Boolean(checked))
-                    }
-                  />
+                  <RadioGroupItem value={String(provider.provider_id)} />
                   <span className="font-medium">{provider.title}</span>
                 </div>
 
@@ -181,11 +199,17 @@ export const LlmSettings = () => {
                 />
               </div>
             ))}
-          </div>
+          </RadioGroup>
         )}
       </CollapsibleSection>
 
-      <CollapsibleSection title="Model Provider" onSave={handleSaveModels} loading={isSavingModels} disabled ={!hasModelChanges}>
+      {/* MODELS */}
+      <CollapsibleSection
+        title="Model Provider"
+        onSave={handleSaveModels}
+        loading={isSavingModels}
+        disabled={!hasModelChanges}
+      >
         <RadioGroup
           value={String(selectedProviderId)}
           onValueChange={(v) => setSelectedProviderId(Number(v))}
@@ -218,7 +242,7 @@ export const LlmSettings = () => {
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <div className="md:col-span-2">
-                          <Input value={model.model} readOnly placeholder="Model" />
+                          <Input value={model.model} readOnly />
                         </div>
                       </TooltipTrigger>
                       <TooltipContent>Model used for this function</TooltipContent>
@@ -226,18 +250,16 @@ export const LlmSettings = () => {
 
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <div>
-                          <Input
-                            type="number"
-                            step="0.1"
-                            min="0"
-                            max="1"
-                            value={model.temperature}
-                            onChange={(e) =>
-                              handleModelChange(model.id, 'temperature', Number(e.target.value))
-                            }
-                          />
-                        </div>
+                        <Input
+                          type="number"
+                          step="0.1"
+                          min="0"
+                          max="1"
+                          value={model.temperature}
+                          onChange={(e) =>
+                            handleModelChange(model.id, 'temperature', Number(e.target.value))
+                          }
+                        />
                       </TooltipTrigger>
                       <TooltipContent>
                         Controls randomness (0 = deterministic, 1 = creative)
@@ -251,7 +273,6 @@ export const LlmSettings = () => {
                         value={model.prompt ?? ''}
                         rows={5}
                         className="resize-none"
-                        placeholder="Prompt"
                         onChange={(e) => handleModelChange(model.id, 'prompt', e.target.value)}
                       />
                     </TooltipTrigger>

--- a/frontend/src/constants/sidebarConfig.ts
+++ b/frontend/src/constants/sidebarConfig.ts
@@ -30,7 +30,7 @@ export const SIDEBAR_CONFIGS: SidebarConfig[] = [
     items: [
       { id: 'site', label: 'Site', icon: LayoutDashboard, path: '/' },
       { id: 'page', label: 'Page', icon: FileText, path: '/page' },
-      { id: 'user', label: 'User', icon: ListTree, path: '/user' },
+      // { id: 'user', label: 'User', icon: ListTree, path: '/user' },
       { id: 'settings', label: 'Settings', icon: Settings, path: '/settings' },
     ],
   },

--- a/llm-service/app/llm/llm_wrapper.py
+++ b/llm-service/app/llm/llm_wrapper.py
@@ -9,12 +9,13 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_anthropic import ChatAnthropic
 from langchain_ollama import ChatOllama
 from langchain.schema import HumanMessage, SystemMessage
+from shared_orm.models.provider import Provider
 
 
 class LLMWrapper:
     """Wrapper class for handling different LLM providers"""
     
-    def __init__(self, config_path=None, llm_provider_choice=1):
+    def __init__(self, db,config_path=None):
         """
         Initialize LLM wrapper with configuration
         
@@ -22,6 +23,7 @@ class LLMWrapper:
             config_path (str, optional): Path to configuration file
             llm_provider_choice (int): Provider choice (1=OpenAI, 2=Groq, 3=Google-Gemini, 4=Anthropic, 5=Ollama)
         """
+        self.db = db
         if config_path is None:
             # Get the package directory and default config path
             package_dir = os.path.dirname(os.path.dirname(__file__))
@@ -29,40 +31,40 @@ class LLMWrapper:
             
         with open(config_path) as f:
             self.config = yaml.safe_load(f)
+        
+        provider_data = self._get_active_provider_from_db()
 
-        # Override provider based on user choice
-        provider_mapping = {
-            1: "openai",
-            2: "groq", 
-            3: "google-gemini",
-            4: "anthropic",
-            5: "ollama"
-        }
-            
-        # self.provider = self.config["model_provider"]
-        # self.provider = provider_mapping[llm_provider_choice]
-        self.provider = provider_mapping.get(llm_provider_choice)
+        self.provider = self._map_provider_name(provider_data.title)
+        self.api_key = provider_data.key
+
         if not self.provider:
-            raise ValueError(f"Invalid provider choice: {llm_provider_choice}. Valid choices: {list(provider_mapping.keys())}")
+            raise ValueError(f"Unsupported provider: {provider_data.title}")
+        if self.provider != "ollama" and not self.api_key:
+            raise ValueError(f"API key missing for provider: {provider_data.title}")
+        
         self.models = self._initialize_models()
 
-    def _get_api_key(self, provider):
-        """Get API key for the specified provider"""
-        if provider == "ollama":
-            return None # Ollama does not require an API key
+    
+    def _get_active_provider_from_db(self):
+
+        provider = (self.db.query(Provider)
+            .filter(Provider.is_active == True)
+            .first()
+        )
+        if not provider:
+            raise ValueError("No active LLM provider found in DB")
         
-        key_mapping = {
-            "openai": "OPENAI_API_KEY",
-            "groq": "GROQ_API_KEY",
-            "google-gemini": "GOOGLE_API_KEY",
-            "anthropic": "ANTHROPIC_API_KEY"
+        return provider
+    
+    def _map_provider_name(self, db_name):
+        mapping = {
+            "OpenAI": "openai",
+            "Gemini": "google-gemini",
+            "Claude": "anthropic",
+            "Ollama": "ollama"
         }
-        
-        api_key = os.getenv(key_mapping[provider])
-        if not api_key:
-            raise ValueError(f"API key not found for provider: {provider}. Set {key_mapping[provider]} environment variable.")
-        
-        return api_key
+        return mapping.get(db_name)
+    
 
     def _initialize_models(self):
         """Initialize model instances based on provider configuration"""
@@ -85,7 +87,7 @@ class LLMWrapper:
         #     "ANTHROPIC_API_KEY"
         # )
 
-        api_key = self._get_api_key(provider)
+        api_key = self.api_key
 
         if provider == "openai":
             return {

--- a/llm-service/app/workers/worker.py
+++ b/llm-service/app/workers/worker.py
@@ -309,7 +309,7 @@ class WorkerService:
             return
 
         driver         = get_driver()
-        llm            = LLMWrapper()
+        llm            = LLMWrapper(db=db)
         prompt_manager = PromptManager()
         cred_service   = TestCredentialService(llm=llm, logger=logger)
 
@@ -579,7 +579,7 @@ class WorkerService:
         await self._notify_ws(page, requested_by)
 
         driver         = get_driver()
-        llm            = LLMWrapper()
+        llm            = LLMWrapper(db=db)
         prompt_manager = PromptManager()
         loop           = asyncio.get_running_loop()
 
@@ -650,7 +650,7 @@ class WorkerService:
             await loop.run_in_executor(
                 None,
                 TestScenarioService(
-                    llm=LLMWrapper(), prompt_manager=PromptManager(), logger=logger
+                    llm=LLMWrapper(db=db), prompt_manager=PromptManager(), logger=logger
                 ).generate,
                 page_id,
                 requested_by,
@@ -729,7 +729,7 @@ class WorkerService:
                 await loop.run_in_executor(
                     None,
                     TestCaseService(
-                        llm=LLMWrapper(), prompt_manager=PromptManager(), logger=logger
+                        llm=LLMWrapper(db=db), prompt_manager=PromptManager(), logger=logger
                     ).generate_for_scenario,
                     page_id,
                     scenario_id,
@@ -740,7 +740,7 @@ class WorkerService:
                 await loop.run_in_executor(
                     None,
                     TestCaseService(
-                        llm=LLMWrapper(), prompt_manager=PromptManager(), logger=logger
+                        llm=LLMWrapper(db=db), prompt_manager=PromptManager(), logger=logger
                     ).generate,
                     page_id,
                     requested_by,
@@ -828,7 +828,7 @@ class WorkerService:
             if require_login:
                 auth_tc = self._get_login_test_case(db, page_id)
                 if auth_tc:
-                    resolved = TestCredentialService(llm=LLMWrapper(), logger=logger).resolve(
+                    resolved = TestCredentialService(llm=LLMWrapper(db=db), logger=logger).resolve(
                         page_id, auth_tc.data.get("test_data", {})
                     )
                     for key, value in resolved.items():
@@ -841,7 +841,7 @@ class WorkerService:
             await loop.run_in_executor(
                 None,
                 TestScriptService(
-                    llm=LLMWrapper(), prompt_manager=PromptManager(), logger=logger
+                    llm=LLMWrapper(db=db), prompt_manager=PromptManager(), logger=logger
                 ).generate_scripts_for_page,
                 page,
                 require_login,
@@ -954,7 +954,7 @@ class WorkerService:
             await loop.run_in_executor(
                 None,
                 TestExecutionService(
-                    llm=LLMWrapper(),
+                    llm=LLMWrapper(db=db),
                     prompt_manager=PromptManager(),
                     logger=logger,
                 ).execute_page,
@@ -1249,7 +1249,7 @@ class WorkerService:
                     return
 
                 resolved = TestCredentialService(
-                    llm=LLMWrapper(), logger=logger
+                    llm=LLMWrapper(db=db), logger=logger
                 ).resolve(auth_page.id, auth_tc.data.get("test_data", {}))
 
                 for key, value in resolved.items():
@@ -1264,7 +1264,7 @@ class WorkerService:
 
             # Drive Selenium login with new credentials
             driver         = get_driver()
-            llm            = LLMWrapper()
+            llm            = LLMWrapper(db=db)
             prompt_manager = PromptManager()
 
             try:
@@ -1382,7 +1382,7 @@ class WorkerService:
     def _run_page_pipeline(self, driver, page: Page, requested_by: int):
 
         logger.info(f"[PIPELINE] Running pipeline | page_id={page.id}")
-        llm = LLMWrapper()
+        llm = LLMWrapper(db=db)
         prompt_manager = PromptManager()
 
         analyzer = PageAnalysisService(
@@ -1449,7 +1449,7 @@ class WorkerService:
             )
             logger.info(f"[PIPELINE] Executing tests | page_id={page.id}")
             TestExecutionService(
-                llm=LLMWrapper(),
+                llm=LLMWrapper(db=db),
                 prompt_manager=PromptManager(),
                 logger=logger,
             ).execute_page(


### PR DESCRIPTION
###  Overview
This PR refactors the LLM provider selection mechanism by moving from environment-based configuration to database-driven configuration. It ensures that only one provider is active at a time and dynamically fetches the provider and API key from the database.

---

###   Changes Made
- Integrated DB-based provider selection using `Provider` model
- Enforced single active provider logic (`is_active = true`)
- Updated `LLMWrapper` to accept DB session for fetching provider details
- Removed dependency on environment variables for API keys
- Added validation for:
  - Unsupported providers
  - Missing API keys 
- Maintained compatibility with existing model initialization logic

---

###   Implementation Details
- Provider is fetched using DB query inside `LLMWrapper`
- Provider title is mapped to internal provider keys (`openai`, `google-gemini`, `anthropic`, etc.)
- API key is retrieved from DB instead of environment variables
- Worker services now pass DB session to `LLMWrapper`

---





