### PR TITLE
chore: display dynamic site title in sidebar for site-info routes

### DIFF
--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -7,7 +7,8 @@ import mindfireLogo from '@/assets/mindfire-logo.png'
 import { useSidebar } from '@/contexts/SidebarContext'
 
 export const Sidebar: React.FC = () => {
-  const { isCollapsed, items, showBack, backTo, backLabel, settingCategories } = useSidebar()
+  const { isCollapsed, items, showBack, backTo, backLabel, settingCategories, siteTitle } =
+    useSidebar()
 
   const navigate = useNavigate()
   const { pathname } = useLocation()
@@ -69,7 +70,6 @@ export const Sidebar: React.FC = () => {
                         )}
                       />
 
-                      {/* TEXT */}
                       <span className={cn(isActive && 'text-[#FC0101]')}>{cat.title}</span>
                     </Link>
                   )
@@ -79,6 +79,13 @@ export const Sidebar: React.FC = () => {
           </React.Fragment>
         ))}
       </nav>
+
+      {siteTitle && !isCollapsed && (
+        <div className="border-t border-border p-4 text-sm text-muted-foreground">
+          <div className="font-semibold text-red-500 text-lg truncate">{siteTitle}</div>{' '}
+          <div className="text-sm text-muted-foreground">Current Site</div>
+        </div>
+      )}
     </aside>
   )
 }

--- a/frontend/src/contexts/SidebarContext.tsx
+++ b/frontend/src/contexts/SidebarContext.tsx
@@ -2,6 +2,8 @@ import React, { createContext, useContext, useState, useMemo, useEffect } from '
 import { useLocation } from 'react-router-dom'
 import { SIDEBAR_CONFIGS, type SidebarItem, type SidebarConfig } from '@/constants/sidebarConfig'
 import { settingApi } from '@/utils/apis/settingApi'
+import { useSiteByIdQuery } from '@/utils/queries/sitesQuery'
+
 type SettingCategory = {
   id: number
   title: string
@@ -25,9 +27,12 @@ type SidebarContextType = {
   backLabel: string | null
   currentConfig: SidebarConfig
   settingCategories: SettingCategory[]
+
+  siteTitle?: string
 }
 
 const SidebarContext = createContext<SidebarContextType | undefined>(undefined)
+
 const toSlug = (title: string) => title.toLowerCase().replace(/\s+/g, '-')
 
 export const SidebarProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -36,11 +41,21 @@ export const SidebarProvider: React.FC<{ children: React.ReactNode }> = ({ child
   const { pathname } = useLocation()
   const [settingCategories, setSettingCategories] = useState<SettingCategory[]>([])
 
-  // Find matching sidebar config based on current path
+  //  Extract siteId from URL
+  const siteId = useMemo(() => {
+    const match = pathname.match(/^\/site-info\/(\d+)/)
+    return match ? Number(match[1]) : null
+  }, [pathname])
+
+  //  Call API
+  const { data: siteData } = useSiteByIdQuery(siteId || 0)
+
+  // Sidebar config
   const currentConfig = useMemo(() => {
     return SIDEBAR_CONFIGS.find((config) => config.pathPattern.test(pathname)) || SIDEBAR_CONFIGS[0]
   }, [pathname])
 
+  // Settings categories
   useEffect(() => {
     if (!settingCategories.length) {
       settingApi.getSettingCategories().then((res) => {
@@ -55,38 +70,27 @@ export const SidebarProvider: React.FC<{ children: React.ReactNode }> = ({ child
   }, [settingCategories.length])
 
   const value: SidebarContextType = {
-    // Mobile menu controls
     isOpen,
     toggle: () => setIsOpen((prev) => !prev),
     close: () => setIsOpen(false),
 
-    // Desktop collapse controls
     isCollapsed,
     toggleCollapse: () => setIsCollapsed((prev) => !prev),
 
-    // Current sidebar items and configuration
     items: currentConfig.items,
     showBack: currentConfig.showBack ?? false,
     backTo: currentConfig.backTo ?? null,
     backLabel: currentConfig.backLabel ?? null,
     currentConfig,
     settingCategories,
+
+    // ✅ Pass site title
+    siteTitle: siteData?.site_title,
   }
 
   return <SidebarContext.Provider value={value}>{children}</SidebarContext.Provider>
 }
 
-/**
- * Hook to access sidebar state and configuration
- *
- * @returns {SidebarContextType} Sidebar context value
- * @throws {Error} If used outside SidebarProvider
- *
- * @example
- * ```tsx
- * const { isCollapsed, items, toggleCollapse } = useSidebar()
- * ```
- */
 export const useSidebar = (): SidebarContextType => {
   const context = useContext(SidebarContext)
   if (!context) {

--- a/frontend/src/types/site.ts
+++ b/frontend/src/types/site.ts
@@ -1,0 +1,7 @@
+export interface GetSiteByIdResponse {
+  id: number
+  site_title: string
+  site_url: string
+  status: 'New' | 'Processing' | 'Done' | 'Pause'
+  created_on: string
+}

--- a/frontend/src/utils/apis/siteApi.ts
+++ b/frontend/src/utils/apis/siteApi.ts
@@ -1,4 +1,5 @@
 // import sites from '@/mock/sites.json'
+import type { GetSiteByIdResponse } from '@/types/site'
 import api from '../axios'
 
 export type Site = {
@@ -110,5 +111,9 @@ export const siteApi = {
   },
   deleteSite: async (siteId: number): Promise<void> => {
     await api.delete(`/sites/${siteId}`)
+  },
+  getSiteById: async (siteId: number): Promise<GetSiteByIdResponse> => {
+    const { data } = await api.get(`/sites/${siteId}`)
+    return data
   },
 }

--- a/frontend/src/utils/queries/sitesQuery.ts
+++ b/frontend/src/utils/queries/sitesQuery.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { siteApi } from '../apis/siteApi'
 import type { CreateSitePayload } from '../apis/siteApi'
 import type { SortType } from '@/types'
+import type { GetSiteByIdResponse } from '@/types/site'
 
 export const useSitesQuery = ({
   page,
@@ -122,6 +123,16 @@ export const useSitePagesQuery = ({
         search,
         sort,
       }),
+
+    enabled: !!siteId,
+  })
+}
+
+export const useSiteByIdQuery = (siteId: number) => {
+  return useQuery<GetSiteByIdResponse>({
+    queryKey: ['site-by-id', siteId],
+
+    queryFn: () => siteApi.getSiteById(siteId),
 
     enabled: !!siteId,
   })


### PR DESCRIPTION
## Description

This PR adds dynamic site context to the sidebar by displaying the current site title based on the URL.

---

##  What’s Added

- Extract `siteId` from `/site-info/:id` routes
- Integrated `getSiteById` API to fetch site details
- Displayed site title at the bottom of the sidebar
- Enhanced UI with larger font and red highlight for better visibility

---

##  Behavior

- Works for all site-related routes:
  - `/site-info/:id`
  - `/site-info/:id/site-page`
  - `/site-info/:id/test-scenario`
- Automatically updates when navigating between sites

---

##  Benefits

- Provides clear context of the current site
- Improves user navigation and awareness
- Maintains consistency across all site-level pages