### PR TITLE
feat: implement site attributes UI and listing with CRUD functionality

### DIFF
--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -85,11 +85,11 @@ const LoginForm: React.FC = () => {
                 )}
               </div>
 
-              <div className="text-right">
+              {/* <div className="text-right">
                 <Link to="/forgot-password" className="text-sm text-gray-600 hover:text-black">
                   Forgot Password?
                 </Link>
-              </div>
+              </div> */}
 
               <Button
                 type="submit"

--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -83,7 +83,7 @@ export const Sidebar: React.FC = () => {
       {siteTitle && !isCollapsed && (
         <div className="border-t border-border p-4 text-sm text-muted-foreground">
           <div className="font-semibold text-red-500 text-lg truncate">{siteTitle}</div>{' '}
-          <div className="text-sm text-muted-foreground">Current Site</div>
+          <div className="text-xs text-muted-foreground">Current Site</div>
         </div>
       )}
     </aside>

--- a/frontend/src/components/site/SiteAttributeSheet.tsx
+++ b/frontend/src/components/site/SiteAttributeSheet.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react'
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetFooter } from '@/components/ui/sheet'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+import { X, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import type { Attribute, EditableField, Props } from '@/types/siteAttribute'
+
+const SiteAttributeSheet: React.FC<Props> = ({ open, onClose, onSubmit, editData, siteId }) => {
+  const isEdit = !!editData
+
+  const [rows, setRows] = useState<Attribute[]>([
+    { site_id: siteId, attribute_key: '', attribute_title: '' },
+  ])
+
+  useEffect(() => {
+    if (editData) {
+      setRows([editData])
+    } else {
+      setRows([{ site_id: siteId, attribute_key: '', attribute_title: '' }])
+    }
+  }, [editData, siteId])
+
+  const handleChange = (index: number, field: EditableField, value: string) => {
+    const updated = [...rows]
+    updated[index][field] = value
+    setRows(updated)
+  }
+
+  const handleAddRow = () => {
+    const last = rows[rows.length - 1]
+
+    if (!last.attribute_key || !last.attribute_title) {
+      toast.error('Fill current row before adding new')
+      return
+    }
+
+    setRows([...rows, { site_id: siteId, attribute_key: '', attribute_title: '' }])
+  }
+
+  const handleRemoveRow = (index: number) => {
+    setRows(rows.filter((_, i) => i !== index))
+  }
+
+  const handleSubmit = () => {
+    for (let row of rows) {
+      if (!row.attribute_key || !row.attribute_title) {
+        toast.error('All fields are required')
+        return
+      }
+    }
+
+    onSubmit(rows)
+    onClose()
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onClose}>
+      <SheetContent side="right" className="w-[420px] flex flex-col p-0">
+        {/* HEADER */}
+        <SheetHeader className="border-b px-6 py-4 relative">
+          <SheetTitle>{isEdit ? 'Update Site Attribute' : 'Add Site Attributes'}</SheetTitle>
+
+          <button onClick={() => onClose()} className="absolute right-4 top-4">
+            <X className="h-4 w-4" />
+          </button>
+        </SheetHeader>
+
+        {/* BODY */}
+        <div className="flex-1 px-6 py-6 space-y-4 overflow-y-auto">
+          {rows.map((row, index) => (
+            <div key={index} className="flex gap-2 items-end">
+              {/* KEY */}
+              <div className="flex-1">
+                <Label>Key</Label>
+                <Input
+                  value={row.attribute_key}
+                  onChange={(e) => handleChange(index, 'attribute_key', e.target.value)}
+                />
+              </div>
+
+              {/* TITLE */}
+              <div className="flex-1">
+                <Label>Title</Label>
+                <Input
+                  value={row.attribute_title}
+                  onChange={(e) => handleChange(index, 'attribute_title', e.target.value)}
+                />
+              </div>
+
+              {/* DELETE */}
+              {!isEdit && (
+                <button
+                  onClick={() => handleRemoveRow(index)}
+                  className="text-red-500 p-2 hover:bg-red-50 rounded"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              )}
+            </div>
+          ))}
+
+          {/* ADD MORE */}
+          {!isEdit && (
+            <button onClick={handleAddRow} className="text-red-500 text-sm cursor-pointer">
+              + Add More
+            </button>
+          )}
+        </div>
+
+        {/* FOOTER */}
+        <SheetFooter className="border-t px-6 py-4">
+          <div className="flex justify-end gap-2 w-full">
+            <Button variant="outline" className="cursor-pointer" onClick={() => onClose()}>
+              Cancel
+            </Button>
+
+            <Button
+              onClick={handleSubmit}
+              className="bg-red-500 hover:bg-red-600 cursor-pointer text-white"
+            >
+              {isEdit ? 'Update' : 'Save'}
+            </Button>
+          </div>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+export default SiteAttributeSheet

--- a/frontend/src/components/site/SiteInfoPage.tsx
+++ b/frontend/src/components/site/SiteInfoPage.tsx
@@ -1,19 +1,33 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { FileText, List, Database, GitBranch, Layout, Calendar } from 'lucide-react'
-// import { Button } from '@/components/ui/button'
+import { FileText, List, Database, GitBranch, Layout, Calendar, MoreVertical } from 'lucide-react'
 import { useSiteInfoQuery } from '@/utils/queries/sitesQuery'
 import StatusBadge from '@/components/status/StatusBadge'
 import StatusDots from '@/components/status/StatusDots'
 import { useWebSocketContext } from '@/contexts/WebSocketProvider'
 import { useQueryClient } from '@tanstack/react-query'
-
+import type { Attribute } from '@/types/siteAttribute'
+import SiteAttributeSheet from './SiteAttributeSheet'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu'
 
 const SiteInfoPage: React.FC = () => {
   const { id } = useParams<{ id: string }>()
   const { data, isLoading, isError } = useSiteInfoQuery(id || '')
   const queryClient = useQueryClient()
   const { lastMessage } = useWebSocketContext()
+
+  const [attributes, setAttributes] = useState<Attribute[]>([
+    { id: 1, site_id: Number(id), attribute_key: 'env', attribute_title: 'Environment' },
+    { id: 2, site_id: Number(id), attribute_key: 'region', attribute_title: 'Region' },
+  ])
+
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const [editData, setEditData] = useState<Attribute | null>(null)
 
   useEffect(() => {
     if (!lastMessage) return
@@ -40,73 +54,72 @@ const SiteInfoPage: React.FC = () => {
     })
   }, [lastMessage, queryClient, id])
 
+  const handleCreate = (data: Attribute[]) => {
+    const newItems = data.map((d, i) => ({
+      id: Date.now() + i,
+      ...d,
+    }))
+    setAttributes((prev) => [...prev, ...newItems])
+  }
+
+  const handleUpdate = (data: Attribute[]) => {
+    const updated = data[0]
+
+    setAttributes((prev) =>
+      prev.map((item) => (item.id === updated.id ? { ...item, ...updated } : item)),
+    )
+  }
+
+  const handleDelete = (id: number) => {
+    setAttributes((prev) => prev.filter((item) => item.id !== id))
+  }
+
   if (isLoading) {
-    return <div className="p-6 text-sm text-gray-500">Loading site info...</div>
+    return <div className="p-6 text-sm text-gray-500">Loading...</div>
   }
 
   if (isError || !data) {
-    return <div className="p-6 text-sm text-red-500">Failed to load site info</div>
+    return <div className="p-6 text-sm text-red-500">Error</div>
   }
+
   const dashboardStats = [
-    { label: 'Pages', value: data.stats.pages, icon: <FileText className="w-5 h-5" /> },
-    { label: 'Test Scenario', value: data.stats.testScenario, icon: <List className="w-5 h-5" /> },
-    { label: 'Test Cases', value: data.stats.testCases, icon: <Database className="w-5 h-5" /> },
-    { label: 'Test Suite', value: data.stats.testSuite, icon: <GitBranch className="w-5 h-5" /> },
-    {
-      label: 'Test Environment',
-      value: data.stats.testEnvironment,
-      icon: <Layout className="w-5 h-5" />,
-    },
-    {
-      label: 'Schedule Test Case',
-      value: data.stats.scheduleTestCase,
-      icon: <Calendar className="w-5 h-5" />,
-    },
+    { label: 'Pages', value: data.stats.pages, icon: <FileText /> },
+    { label: 'Test Scenario', value: data.stats.testScenario, icon: <List /> },
+    { label: 'Test Cases', value: data.stats.testCases, icon: <Database /> },
+    { label: 'Test Suite', value: data.stats.testSuite, icon: <GitBranch /> },
+    { label: 'Test Environment', value: data.stats.testEnvironment, icon: <Layout /> },
+    { label: 'Schedule Test Case', value: data.stats.scheduleTestCase, icon: <Calendar /> },
   ]
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[6.5fr_3.5fr] gap-8 mx-auto">
-      {/* LEFT COLUMN */}
+      {/* LEFT */}
       <div className="flex flex-col gap-8">
-        {/* Analyze Process */}
-        <div className="border border-[#E4D7D7] bg-white rounded-[6px] overflow-hidden">
-          <div className="bg-[#FFF8F8] border-b border-[#E4D7D7] py-3 px-4">
-            <h2 className="text-[15px] font-semibold text-[#322525]">Analyze Process</h2>
+        <div className="border border-[#E4D7D7] bg-white rounded-[6px]">
+          <div className="bg-[#FFF8F8] border-b px-4 py-3">
+            <h2 className="text-[15px] font-semibold">Analyze Process</h2>
           </div>
 
-          <div className="p-5 flex items-center justify-between">
-            <div className="flex flex-col gap-2">
+          <div className="p-5 flex justify-between">
+            <div>
               <StatusBadge status={data.analyzeStatus} />
               <StatusDots status={data.analyzeStatus} />
             </div>
-
-            {/* {data.analyzeStatus === 'Processing' && (
-              <Button
-                variant="outline"
-                className="border-[#E63B3B] text-[#E63B3B] hover:bg-[#FFF0F0]"
-              >
-                View Logs
-              </Button>
-            )} */}
           </div>
         </div>
 
-        {/* Site Dashboard */}
-        <div className="border border-[#E4D7D7] bg-white rounded-[6px] overflow-hidden">
-          <div className="bg-[#FFF8F8] border-b border-[#E4D7D7] py-3 px-4">
-            <h2 className="text-[15px] font-semibold text-[#322525]">Site Dashboard</h2>
+        <div className="border border-[#E4D7D7] bg-white rounded-[6px]">
+          <div className="bg-[#FFF8F8] border-b px-4 py-3">
+            <h2 className="text-[15px] font-semibold">Site Dashboard</h2>
           </div>
 
-          <div className="p-6 grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="p-5 grid grid-cols-2 gap-4">
             {dashboardStats.map((stat) => (
-              <div
-                key={stat.label}
-                className="flex items-center border border-[#EFE3E3] rounded-lg p-4"
-              >
-                <div className="bg-[#F6F0F0] p-3 rounded-lg mr-4">{stat.icon}</div>
+              <div key={stat.label} className="border p-4 rounded-lg flex gap-3">
+                {stat.icon}
                 <div>
-                  <p className="text-xs text-[#8B6E6E]">{stat.label}</p>
-                  <p className="text-2xl font-bold text-[#2B1F1F]">{stat.value}</p>
+                  <p className="text-xs">{stat.label}</p>
+                  <p className="font-bold">{stat.value}</p>
                 </div>
               </div>
             ))}
@@ -114,38 +127,107 @@ const SiteInfoPage: React.FC = () => {
         </div>
       </div>
 
-      {/* RIGHT COLUMN */}
-      <div className="border border-[#E4D7D7] bg-white rounded-[6px] h-fit">
-        <div className="bg-[#FFF8F8] border-b border-[#E4D7D7] py-3 px-4">
-          <h2 className="text-[15px] font-semibold text-[#322525]">Site Detail</h2>
+      {/* RIGHT */}
+      <div className="flex flex-col gap-6">
+        {/* SITE DETAIL */}
+        <div className="border border-[#E4D7D7] bg-white rounded-[6px]">
+          <div className="bg-[#FFF8F8] border-b px-4 py-3">
+            <h2 className="text-[15px] font-semibold">Site Detail</h2>
+          </div>
+
+          <div className="p-4 space-y-3">
+            <DetailItem label="Created On" value={new Date(data.createdAt).toLocaleString()} />
+            <DetailItem label="Updated On" value={new Date(data.updatedAt).toLocaleString()} />
+            <DetailItem label="Site Title" value={data.title} />
+
+            <div>
+              <p className="text-[11px] text-[#8B6E6E]">Site URL</p>
+              <a href={data.url} target="_blank" rel="noreferrer" className="text-blue-500">
+                {data.url}
+              </a>
+            </div>
+          </div>
         </div>
 
-        <div className="p-6 space-y-6">
-          <DetailItem label="Created On" value={new Date(data.createdAt).toLocaleString('en-GB')} />
-          <DetailItem label="Updated On" value={new Date(data.updatedAt).toLocaleString('en-GB')} />
-          <DetailItem label="Site Title" value={data.title} />
+        {/* SITE ATTRIBUTES */}
+        {/* SITE ATTRIBUTES */}
+        <div className="border border-[#E4D7D7] bg-white rounded-[6px]">
+          <div className="bg-[#FFF8F8] border-b py-3 px-4 flex justify-between items-center">
+            <h2 className="text-[15px] font-semibold">Site Attributes</h2>
 
-          <div>
-            <p className="text-[11px] font-semibold uppercase text-[#8B6E6E] mb-1">Site URL</p>
-            <a
-              href={data.url}
-              target="_blank"
-              rel="noreferrer"
-              className="text-[#2761FF] hover:underline break-all"
+            <button
+              onClick={() => {
+                setEditData(null)
+                setSheetOpen(true)
+              }}
+              className="text-red-500 border border-red-500 px-3 py-1 rounded text-sm cursor-pointer"
             >
-              {data.url}
-            </a>
+              + Add Attribute
+            </button>
+          </div>
+
+          <div className="p-4 max-h-[220px] overflow-y-auto hide-scrollbar">
+            {attributes.length === 0 ? (
+              <p className="text-sm text-gray-400">No attributes added</p>
+            ) : (
+              attributes.map((attr) => (
+                <div key={attr.id} className="flex justify-between items-center border-b py-2">
+                  <div>
+                    <p className="font-medium">{attr.attribute_key}</p>
+                    <p className="text-xs text-gray-500">{attr.attribute_title}</p>
+                  </div>
+
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button className="p-2 hover:bg-gray-100 rounded cursor-pointer">
+                        <MoreVertical className="w-4 h-4" />
+                      </button>
+                    </DropdownMenuTrigger>
+
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onClick={() => {
+                          setEditData(attr)
+                          setSheetOpen(true)
+                        }}
+                      >
+                        Update
+                      </DropdownMenuItem>
+
+                      <DropdownMenuItem
+                        onClick={() => {
+                          if (attr.id !== undefined) {
+                            handleDelete(attr.id)
+                          }
+                        }}
+                        className="text-red-500"
+                      >
+                        Delete
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              ))
+            )}
           </div>
         </div>
       </div>
+
+      <SiteAttributeSheet
+        open={sheetOpen}
+        onClose={() => setSheetOpen(false)}
+        onSubmit={editData ? handleUpdate : handleCreate}
+        editData={editData}
+        siteId={Number(id)}
+      />
     </div>
   )
 }
 
 const DetailItem: React.FC<{ label: string; value: string }> = ({ label, value }) => (
   <div>
-    <p className="text-[11px] font-semibold uppercase text-[#8B6E6E] mb-1">{label}</p>
-    <p className="text-sm font-medium text-[#2B1F1F]">{value}</p>
+    <p className="text-[11px] text-[#8B6E6E]">{label}</p>
+    <p className="text-sm font-medium">{value}</p>
   </div>
 )
 

--- a/frontend/src/types/siteAttribute.ts
+++ b/frontend/src/types/siteAttribute.ts
@@ -1,0 +1,15 @@
+export type Attribute = {
+  id?: number
+  site_id: number
+  attribute_key: string
+  attribute_title: string
+}
+
+export type Props = {
+  open: boolean
+  onClose: () => void
+  onSubmit: (data: Attribute[]) => void
+  editData?: Attribute | null
+  siteId: number
+}
+  export type EditableField = 'attribute_key' | 'attribute_title'


### PR DESCRIPTION
## Overview
This PR introduces the **Site Attributes** feature in the Site Info page, enabling users to manage attributes associated with a site.

---

##  Features Implemented

###  UI Enhancements
- Added a **separate Site Attributes section** below Site Details
- Designed a **scrollable attributes list** with hidden scrollbar
- Implemented consistent UI using existing design system (`#FFF8F8`, `text-red-500`, etc.)

###  Create (Bulk)
- Added **"Add Attribute" button** to open a side sheet
- Supports adding **one or multiple attributes at once**
- Prevents adding new rows until current row is filled

###  Update
- Reused the same sheet for editing a single attribute
- Pre-filled form fields based on selected attribute

###  Delete
- Added **dropdown menu (Radix UI)** for each attribute
- Supports delete action per attribute

###  Reusability
- Created a reusable **SiteAttributeSheet component**
- Handles both create and update flows

---

##  Data Handling
- Integrated `site_id` into create and update payloads
- Mock data used for now (API integration can be added later)
- Maintains clean separation between UI state and backend structure

---

##  Validation
- Required field validation for `attribute_key` and `attribute_title`
- Prevents empty submissions
- Prevents adding new row without completing current row

---

##  Files Added / Updated
- `SiteAttributeSheet.tsx`
- `SiteInfoPage.tsx`

---

##  Next Steps 
- Integrate backend APIs (create, update, delete)
- Add optimistic updates with React Query
- Add delete confirmation modal

---



