### PR TITLE
fix: disable run action for test suites in running state

### DIFF
--- a/frontend/src/components/site/TestSuite.tsx
+++ b/frontend/src/components/site/TestSuite.tsx
@@ -72,11 +72,16 @@ const SuiteCard: React.FC<SuiteCardProps> = ({ suite, onEdit, onDelete, onRun })
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem
-                onClick={() => onRun(suite)}
-                className="cursor-pointer text-sm flex items-center gap-2 text-emerald-600"
-              >
+                onClick={() => suite.status !== 'running' && onRun(suite)}
+                disabled={suite.status === 'running'}
+                className={`text-sm flex items-center gap-2 ${
+                  suite.status === 'running'
+                    ? 'text-gray-400 cursor-not-allowed'
+                    : 'text-emerald-600 cursor-pointer'
+                }`}
+               >
                 <Play className="w-3.5 h-3.5" />
-                Run Test Suite
+                {suite.status === 'running' ? 'Running...' : 'Run Test Suite'}
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => onEdit(suite)} className="cursor-pointer text-sm">
                 Edit


### PR DESCRIPTION
## Description

Disabled the **"Run Test Suite"** action when a suite is already in `running` state to prevent duplicate executions.

## Changes
- Disabled Run action in dropdown when suite status is `running`
- Added visual feedback (disabled state + cursor change)
- Updated label to show **"Running..."** for better UX

## Impact
- Prevents duplicate execution triggers
- Improves UI clarity and user experience